### PR TITLE
Wagon unmaintained; added wazero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2145,7 +2145,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
 
 
 
-## <a name="wazero"></a>[wazero](https://github.com/tetratelabs/wazero) <sup>[top⇈](#contents)</sup>
+## <a name="wazero"></a>[wazero](https://wazero.io) <sup>[top⇈](#contents)</sup>
 > wazero is a WebAssembly 1.0 spec compliant runtime written in Go, with zero platform dependencies.
 
 * **Languages written in**

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo contains a list of virtual machines and tools that execute the WebAsse
 - [Swam](#swam) <sup><sup>:rocket:</sup></sup></br>
 - [VMIR](#vmir) <sup><sup>:sleeping:</sup></sup></br>
 - [wac](#wac) <sup><sup>:sleeping:</sup></sup></br>
-- [Wagon](#wagon) <sup><sup>:rocket:</sup></sup></br>
+- [Wagon](#wagon) <sup><sup>:sleeping:</sup></sup></br>
 - [WAKit](#wakit) <sup><sup>:rocket:</sup></sup></br>
 - [Warpy](#warpy) <sup><sup>:sleeping:</sup></sup></br>
 - [WasmEdge](#wasmedge) <sup><sup>:rocket:</sup></sup></br>
@@ -40,6 +40,7 @@ This repo contains a list of virtual machines and tools that execute the WebAsse
 - [WebAssembly](#webassembly) <sup><sup>:sleeping:</sup></sup></br>
 - [WebAssembly Micro Runtime](#wamr) <sup><sup>:rocket:</sup></sup></br>
 - [TWVM](#twvm) <sup><sup>:rocket:</sup></sup></br>
+- [wazero](#wazero) <sup><sup>:rocket:</sup></sup></br>
 
 ----------------
 
@@ -2127,6 +2128,81 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
 * **Non-web standards**
 
     - `N/A`
+
+* **Used by**
+
+    - `N/A`
+
+* **Platforms supported**
+
+    <table>
+    <tr>
+        <td>Linux</td>
+        <td>macOS</td>
+        <td>Windows</td>
+    </tr>
+    </table>
+
+
+
+## <a name="wazero"></a>[wazero](https://github.com/tetratelabs/wazero) <sup>[top⇈](#contents)</sup>
+> wazero is a WebAssembly 1.0 spec compliant runtime written in Go, with zero platform dependencies.
+
+* **Languages written in**
+
+    <table>
+    <tr>
+        <td>Go</td>
+    </tr>
+    </table>
+
+* **Compiler framework**
+
+    <table>
+    <tr>
+        <td>Custom</td>
+    </tr>
+    </table>
+
+
+* **Compilation / Execution modes**
+
+    <table>
+    <tr>
+        <td>Interpreted</td>
+        <td>JIT</td>
+    </tr>
+    </table>
+
+* **Interoperability with other languages**
+
+    - `N/A`
+
+* **Non-MVP features supported**
+
+    <table>
+    <tr>
+        <td>Import/Export of Mutable Globals</td>
+        <td>Sign-extension operators</td>
+        <td>Multi-Value Returns</td>
+    </tr>
+    </table>
+
+* **Host APIs supported**
+
+    <table>
+    <tr>
+        <td>WASI</td>
+    </tr>
+    </table>
+
+* **Non-web standards**
+
+    <table>
+    <tr>
+        <td>WASI</td>
+    </tr>
+    </table>
 
 * **Used by**
 

--- a/README.md
+++ b/README.md
@@ -2185,6 +2185,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
         <td>Import/Export of Mutable Globals</td>
         <td>Sign-extension operators</td>
         <td>Multi-Value Returns</td>
+        <td>Non-trapping float-to-int conversions</td>
     </tr>
     </table>
 
@@ -2206,17 +2207,20 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
 
 * **Used by**
 
-    - `N/A`
+    - [wapc-go](https://github.com/wapc/wapc-go) - WebAssembly Host Runtime for waPC-compliant modules
 
 * **Platforms supported**
 
+    JIT:
     <table>
     <tr>
-        <td>Linux</td>
-        <td>macOS</td>
-        <td>Windows</td>
+        <td>amd64</td>
+        <td>arm64</td>
     </tr>
     </table>
+    
+    Interpretted:
+    - All platforms targetted by the Go compiler.
 
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ GraalWasm is a WebAssembly engine implemented in the GraalVM. It can interpret a
 
 ## <a name="happy-new-moon-with-report"></a>[Happy New Moon With Report](https://github.com/fishjd/HappyNewMoonWithReport) <sup>[top⇈](#contents)</sup>
 
-Happy New Moon with Report is an open-source implementation of WebAssembly written entirely in Java. It is used to run or test Web Assembly Modules (*.wasm) in Java. 
+Happy New Moon with Report is an open-source implementation of WebAssembly written entirely in Java. It is used to run or test Web Assembly Modules (*.wasm) in Java.
 
 * **Languages written in**
 
@@ -462,7 +462,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
 * **Used by**
 
     - `N/A`
-    
+
 
 * **Platforms supported**
 
@@ -474,7 +474,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
         <td>Windows</td>
     </tr>
     </table>
-    
+
 ## <a name="innative"></a>[inNative](https://github.com/innative-sdk/innative) <sup>[top⇈](#contents)</sup>
 > An AOT (ahead-of-time) compiler for WebAssembly that creates C compatible binaries, either as sandboxed plugins you can dynamically load, or as stand-alone executables that interface directly with the operating system.
 
@@ -721,7 +721,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
     <tr>
         <td>Multi-Value</td>
         <td>Bulk Memory Operations</td>
-        <td>Sign-extension operators</td>        
+        <td>Sign-extension operators</td>
         <td>Non-trapping conversions</td>
         <td>Name Section</td>
     </tr>
@@ -1345,7 +1345,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
         <td>Zig</td>
         <td>Ruby</td>
     </tr>
-    </table> 
+    </table>
 
 * **Non-MVP features supported**
 
@@ -1372,7 +1372,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
         <td>Command Interface</td>
         <td>Image Processing</td>
     </tr>
-    </table> 
+    </table>
 
 * **Non-web standards**
 
@@ -1384,7 +1384,7 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
         <td>Oasis</td>
         <td>Substrate</td>
     </tr>
-    </table> 
+    </table>
 
 * **Used by**
 
@@ -2211,17 +2211,13 @@ Happy New Moon with Report is an open-source implementation of WebAssembly writt
 
 * **Platforms supported**
 
-    JIT:
     <table>
     <tr>
-        <td>amd64</td>
-        <td>arm64</td>
+        <td>Linux (amd64, arm64, riscv64)</td>
+        <td>macOs (amd64)</td>
+        <td>Windows (amd64)</td>
     </tr>
     </table>
-    
-    Interpretted:
-    - All platforms targetted by the Go compiler.
-
 -------------------
 
 ## License


### PR DESCRIPTION
Wagon's last commit was in 2020, where it recommended looking at wazero before being archived.

wazero is thus the only actively maintained wasm runtime written in Go.