### PR TITLE
Update README.md: move WAVM to sleepy

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repo contains a list of virtual machines and tools that execute the WebAsse
 - [Wasmtime](#wasmtime) <sup><sup>:rocket:</sup></sup></br>
 - [WasmVM](#wasmvm1) <sup><sup>:rocket:</sup></sup></br>
 - [WasmVM](#wasmvm2) <sup><sup>:sleeping:</sup></sup></br>
-- [WAVM](#wavm) <sup><sup>:rocket:</sup></sup></br>
+- [WAVM](#wavm) <sup><sup>:sleeping:</sup></sup></br>
 - [WebAssembly](#webassembly) <sup><sup>:sleeping:</sup></sup></br>
 - [WebAssembly Micro Runtime](#wamr) <sup><sup>:rocket:</sup></sup></br>
 - [Wizard Research Engine](#wizard) <sup><sup>:rocket:</sup></sup></br>


### PR DESCRIPTION
WAVM has not been updated in 2 years: https://github.com/WAVM/WAVM